### PR TITLE
Improve loading of saved objects

### DIFF
--- a/kibana/saved_objects.py
+++ b/kibana/saved_objects.py
@@ -167,7 +167,7 @@ class SavedObjectController(GenericController):
                     create_new_copies=(not overwrite),
                 )
                 logger.info(
-                    "Successfully imported {count} out of {total} saved objects."
+                    "Successfully imported {count} out of {total} saved objects.".format(count=results["successCount"], total=object_count)
                 )
                 failed_ids = []
                 for failure in results["errors"]:

--- a/kibana/saved_objects.py
+++ b/kibana/saved_objects.py
@@ -96,8 +96,8 @@ class SavedObjectController(GenericController):
         overwrite: bool = None,
         compatibility_mode: bool = None,
         timeout: int = 10,
-        resolve:bool=False,
-        retries:dict=None,
+        resolve: bool = False,
+        retries: dict = None,
     ):
         """
         Import saved objects from a previously exported saved objects file.
@@ -116,15 +116,17 @@ class SavedObjectController(GenericController):
         query_params = self._clean_params(query_params)
 
         if resolve:
-            action="_resolve_import_errors"
-            form_data={"retries": json.dumps(retries)}
+            action = "_resolve_import_errors"
+            form_data = {"retries": json.dumps(retries)}
             query_params.pop("overwrite", None)
         else:
-            action="_import"
-            form_data={}
+            action = "_import"
+            form_data = {}
 
         if space_id is not None:
-            endpoint = "/s/{space}/api/saved_objects/{action}".format(space=space_id, action=action)
+            endpoint = "/s/{space}/api/saved_objects/{action}".format(
+                space=space_id, action=action
+            )
         else:
             endpoint = "/api/saved_objects/{}".format(action)
 
@@ -136,7 +138,6 @@ class SavedObjectController(GenericController):
             upload_filename += ".ndjson"
         else:
             upload_filename = file.name
-
 
         files = {"file": (upload_filename, file, "application/ndjson")}
 
@@ -151,7 +152,7 @@ class SavedObjectController(GenericController):
         overwrite: bool = True,
         delete_after_import: bool = False,
         allow_failure: bool = False,
-        no_resolve_broken: bool=False,
+        no_resolve_broken: bool = False,
         data_directory: os.PathLike = None,
         **kwargs
     ):
@@ -184,7 +185,9 @@ class SavedObjectController(GenericController):
                     create_new_copies=(not overwrite),
                 )
                 logger.info(
-                    "Successfully imported {count} out of {total} saved objects.".format(count=results["successCount"], total=object_count)
+                    "Successfully imported {count} out of {total} saved objects.".format(
+                        count=results["successCount"], total=object_count
+                    )
                 )
                 failed_ids = []
                 retries = []
@@ -203,12 +206,12 @@ class SavedObjectController(GenericController):
                     logger.warning(msg, extra={"error": failure["error"]})
                     failed_ids.append(failure["id"])
                     retries.append(
-                            {
-                                "id": failure["id"],
-                                "type": failure["type"],
-                                "overwrite": overwrite,
-                                "ignoreMissingReferences": True
-                            }
+                        {
+                            "id": failure["id"],
+                            "type": failure["type"],
+                            "overwrite": overwrite,
+                            "ignoreMissingReferences": True,
+                        }
                     )
 
                 if failed_ids and not no_resolve_broken:
@@ -222,8 +225,18 @@ class SavedObjectController(GenericController):
                             }
                         )
                     intermediate_file.seek(0)
-                    resolutions = self.import_objects(intermediate_file, overwrite=overwrite, create_new_copies=(not overwrite), resolve=True, retries=retries)
-                    logger.info("Successfully retried {} objects.".format(resolutions["successCount"]))
+                    resolutions = self.import_objects(
+                        intermediate_file,
+                        overwrite=overwrite,
+                        create_new_copies=(not overwrite),
+                        resolve=True,
+                        retries=retries,
+                    )
+                    logger.info(
+                        "Successfully retried {} objects.".format(
+                            resolutions["successCount"]
+                        )
+                    )
             except httpx.HTTPStatusError as e:
                 if allow_failure:
                     logger.info(


### PR DESCRIPTION
If a saved objects import request fails, it returns a list of failures; and if even one of the objects is marked as a failure, all the objects are discarded (even though they were marked as "successful".)

It's entirely possible for a valid export to contain objects with, for example, broken references -- so we want to have the option to push objects in even if they might have some errors. To do that, we need to use the [Resolve Import Errors API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-resolve-import-errors.html#saved-objects-api-resolve-import-errors-example-2).

This also adds more robust logging to the saved objects load controller.