### PR TITLE
Hotfix: discard stats file as a separate operation

### DIFF
--- a/elastic_stacker/elasticsearch/transforms.py
+++ b/elastic_stacker/elasticsearch/transforms.py
@@ -241,7 +241,8 @@ class TransformController(ElasticsearchAPIController):
         #     for t in self._depaginate(self.stats, "transforms", page_size=100)
         # }
 
-        transform_files = set(working_directory.glob("*.json")).discard(stats_file)
+        transform_files = set(working_directory.glob("*.json"))
+        transform_files.discard(stats_file)
         for transform_file in transform_files:
             logger.debug("Loading {}".format(transform_file))
             transform_id = transform_file.stem


### PR DESCRIPTION
A recent change broke the transform controller's load routine. It used a set object containing all the files to be imported, and used the `set.discard` method to remove a metadata file from the set. However, the set.discard method returns None and mutates the set object it was called on, rather than acting like a set difference operation that returns the set without that element.