### PR TITLE
Two bugfixes

### DIFF
--- a/elastic_stacker/__about__.py
+++ b/elastic_stacker/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present James Taliaferro <taliaferro1@llnl.gov>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/elastic_stacker/kibana/saved_objects.py
+++ b/elastic_stacker/kibana/saved_objects.py
@@ -98,7 +98,6 @@ class SavedObjectController(GenericController):
         create_new_copies: bool = None,
         overwrite: bool = None,
         compatibility_mode: bool = None,
-        timeout: int = 10,
         resolve: bool = False,
         retries: dict = None,
     ):
@@ -143,7 +142,7 @@ class SavedObjectController(GenericController):
         files = {"file": (upload_filename, file, "application/ndjson")}
 
         response = self._client.post(
-            endpoint, params=query_params, files=files, data=form_data, timeout=timeout
+            endpoint, params=query_params, files=files, data=form_data
         )
         return response.json()
 

--- a/elastic_stacker/utils/client.py
+++ b/elastic_stacker/utils/client.py
@@ -46,7 +46,7 @@ class APIClient(httpx.Client):
             kwargs["cert"] = tls_params["cert"]
 
         # restore old HTTPX behavior
-        ca = kwargs.pop("verify")
+        ca = kwargs.pop("verify", None)
         if ca is None:
             pass
         elif os.path.isdir(ca):


### PR DESCRIPTION
This PR fixes two small issues. 
The first is a discrepancy with the timeout parameter, which was being overridden and set to ten seconds by an internal function when loading saved objects. 
The second is an issue with how the `verify` parameter was interpreted. In #26 we updated the way this parameter works, to accommodate a change in the underlying library HTTPX. However, the edge case where that parameter isn't provided at all was missed, and led to a crash.